### PR TITLE
3주차 스터디(투포인터/이분탐색)

### DIFF
--- a/src/PS/boj/study_W3/prob1072_게임.java
+++ b/src/PS/boj/study_W3/prob1072_게임.java
@@ -1,0 +1,33 @@
+package PS.boj.study_W3;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.StringTokenizer;
+
+public class prob1072_게임 {
+
+    public static void main(String[] args) throws IOException {
+        long x, y;
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(in.readLine(), " ");
+        ;
+        StringBuilder sb = new StringBuilder();
+        x = Integer.parseInt(st.nextToken());
+        y = Integer.parseInt(st.nextToken());
+
+        double cur = y * 100 / x;
+
+        if(cur>=99){
+            System.out.println(-1);
+        }else {
+            double a=Math.ceil(((cur+1)*x-(100*y))/(99-cur));
+            System.out.println((int)a);
+        }
+    }
+}
+

--- a/src/PS/boj/study_W3/prob1654_랜선자르기.java
+++ b/src/PS/boj/study_W3/prob1654_랜선자르기.java
@@ -1,0 +1,49 @@
+package PS.boj.study_W3;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class prob1654_랜선자르기 {
+
+    public static void main(String[] args) throws IOException {
+        int k,n,val;
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        st= new StringTokenizer(in.readLine()," ");
+        k=Integer.parseInt(st.nextToken());
+        n=Integer.parseInt(st.nextToken());
+
+        int v[]=new int [k];
+        for (int i = 0; i < k; i++) {
+            v[i]=Integer.parseInt(in.readLine());
+        }
+        Arrays.sort(v);
+        int index=k-1;
+        long cnt=0L;
+        long s=1L, e=v[index];
+        e++;
+        long len=(s+e)/2;
+        while(s<e){
+            cnt=0;
+            for (int i = 0; i < k; i++) {
+                cnt+=v[i]/len;
+            }
+            if(cnt>=n){
+                s=len+1;
+                len=(s+e)/2;
+            }
+            else {
+                e=len;
+                len=(s+e)/2;
+            }
+        }
+        System.out.println(s-1);
+
+    }
+}

--- a/src/PS/boj/study_W3/prob18870_좌표압축.java
+++ b/src/PS/boj/study_W3/prob18870_좌표압축.java
@@ -1,0 +1,54 @@
+package PS.boj.study_W3;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.StringTokenizer;
+
+public class prob18870_좌표압축 {
+
+    public static void main(String[] args) throws IOException {
+        int m,n;
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        n=Integer.parseInt(in.readLine());
+
+        ArrayList<int[]> v= new ArrayList<>();
+
+        st=new StringTokenizer(in.readLine()," ");
+        for (int i = 0; i < n; i++) {
+            v.add(new int[]{Integer.parseInt(st.nextToken()),i});
+        }
+
+        Collections.sort(v, new Comparator<int[]>() {
+            @Override
+            public int compare(int[] o1, int[] o2) {
+                return o1[0]-o2[0];
+            }
+        });
+
+        int arr[]= new int[n];
+        arr[v.get(0)[1]]=0;
+
+        for (int i = 1; i < v.size(); ++i) {
+            if (v.get(i)[0]>v.get(i-1)[0]){
+                arr[v.get(i)[1]]=arr[v.get(i-1)[1]]+1;
+            }
+            else{
+                arr[v.get(i)[1]]=arr[v.get(i-1)[1]];
+            }
+        }
+        for (int i = 0; i < n; ++i) {
+           sb.append(arr[i]).append(" ");
+        }
+        System.out.println(sb);
+
+    }
+}
+

--- a/src/PS/boj/study_W3/prob2343_기타레슨.java
+++ b/src/PS/boj/study_W3/prob2343_기타레슨.java
@@ -1,0 +1,57 @@
+package PS.boj.study_W3;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class prob2343_기타레슨 {
+
+    public static void main(String[] args) throws IOException {
+        int m,n;
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        st=new StringTokenizer(in.readLine()," ");
+        n=Integer.parseInt(st.nextToken());
+        m=Integer.parseInt(st.nextToken());
+int s=0,e=0;
+        int []arr= new int[n];
+        st=new StringTokenizer(in.readLine()," ");
+        for (int i = 0; i < n; i++) {
+            arr[i]=Integer.parseInt(st.nextToken());
+            e+=arr[i];
+            if(s<arr[i]) {
+            s=arr[i];
+            }
+        }
+
+
+        while (s < e) {
+            int mid = (s + e) / 2;
+
+            int sum = 0, cnt = 0;
+            for (int i = 0; i < n; i++) {
+                if (sum + arr[i] > mid) {
+                    sum = 0;
+                    cnt++;
+                }
+                sum += arr[i];
+            }
+            if (sum != 0) cnt++;
+
+            if (cnt > m) {
+                s = mid + 1;
+            }
+            else {
+                e = mid;
+            }
+        }
+        System.out.println(s);
+
+    }
+}
+

--- a/src/PS/boj/study_W3/prob2470_두용액.java
+++ b/src/PS/boj/study_W3/prob2470_두용액.java
@@ -1,0 +1,51 @@
+package PS.boj.study_W3;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class prob2470_두용액 {
+
+    public static void main(String[] args) throws IOException {
+        int m,n;
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        n=Integer.parseInt(in.readLine());
+
+        int v[]= new int[n];
+
+        st=new StringTokenizer(in.readLine()," ");
+        for (int i = 0; i < n; i++) {
+            v[i]=Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(v);
+        int s=0,e=n-1;
+        int ss=0,ee=0;
+        int min=2000000000;
+
+        while(s<e){
+            int sum=v[s]+v[e];
+            if(Math.abs(sum)<min){
+                min=Math.abs(sum);
+                ss=s;
+                ee=e;
+                if(min==0)break;
+            }
+            if(Math.abs(v[s])<Math.abs(v[e])){
+                e--;
+            }
+            else{
+                s++;
+            }
+        }
+        sb.append(v[ss]).append(" ").append(v[ee]);
+        System.out.println(sb);
+
+    }
+}
+

--- a/src/PS/boj/study_W3/prob2512_예산.java
+++ b/src/PS/boj/study_W3/prob2512_예산.java
@@ -1,0 +1,54 @@
+package PS.boj.study_W3;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class prob2512_예산 {
+
+    public static void main(String[] args) throws IOException {
+        int m,n,val;
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+
+        n=Integer.parseInt(in.readLine());
+        st= new StringTokenizer(in.readLine()," ");
+        int v[]=new int [n];
+        for (int i = 0; i < n; i++) {
+            v[i]=Integer.parseInt(st.nextToken());
+        }
+        m=Integer.parseInt(in.readLine());
+        Arrays.sort(v);
+        long len=v[0];
+        long sum=0;
+        long s=1,e=v[n-1];
+        e++;
+        while(s<e){
+            sum=0;
+            for (int i = 0; i < n; ++i) {
+                if(v[i]>len){
+                    sum+=len;
+                }
+                else{
+                    sum+=v[i];
+                }
+            }
+            if(sum<=m){
+                s=len+1;
+                len=(s+e)/2;
+            }
+            else{
+                e=len;
+                len=(s+e)/2;
+            }
+        }
+        System.out.println(s-1);
+
+    }
+}
+


### PR DESCRIPTION
# 💡 PR Summary - 자바 알고리즘 3주차 코드 리뷰
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
>1. prob 1072 게임
    - 수학 식을 활용해서 해결. 
    -  (이겨야 하는 횟수)=Math.ceil(((cur+1)*x-(100*y))/(99-cur)); //cur은 현재 승률

>2. prob 1654 랜선 자르기
    - upper-bound를 활용
    - 랜선의 길이를 배열에 저장한 뒤  cnt+=v[i]/len; 식을 활용해 자른 랜선의 수 계산

>3. prob 18870 좌표압축
    - Collections.sort( list, new Comparator) 활용하여 좌표와 입력순서를 오름차순 정렬
    - 정렬한 리스트를 순차적으로 순회하며 해당 값 전에 위치한 원소의 개수 저장

>4. prob 2343 기타 레슨
    - 블루레이 용량에 따른 필요한 개수를 cnt에 저장하여 이분탐색 진행!

>5.  prob 2470 두 용액
    - 용액을 정렬한뒤 투포인터를 활용하여 각 용액의 합 비교.
    
### 📖 Related Issues

---
<!-- 예시) #1 -->
**이슈 번호 1
투포인터 활용 upper-bound/ lower-bound 관련 내용 정리
https://parang-log.tistory.com/42


### 📚 Etc

---
| prob   | memory  |  time |---level|
| ------ | ----------- |-----|-----|
|prob1654_랜선자르기|15652kb | 148ms | S2|
|prob2512_예산|14152kb | 124ms | S3|
|prob2343_기타 레슨|22532kb | 252ms | S1|
|prob18870_기타 레슨|263368kb | 1600ms | S2|
|prob2470_두 용액|31236kb | 284ms | G5|
|prob1072_게임|11532kb | 80ms | S3|


